### PR TITLE
nodeName > tagName

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Function to prevent any event from being executed based on anything related to t
 
 ```html
 <GlobalEvents
-  :filter="(event, handler, eventName) => event.target.tagName !== 'INPUT'"
+  :filter="(event, handler, eventName) => event.target.nodeName !== 'INPUT'"
   @keyup.prevent.space.exact="nextTab"
 />
 ```


### PR DESCRIPTION
I would go with `nodeName` over `tagName` due to its support for a wider range of scenarios and potentially better forward compatibility.

Reference: https://stackoverflow.com/questions/4878484/difference-between-tagname-and-nodename